### PR TITLE
fixes version numbers for dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 node_modules/montage
 .DS_Store
+node_modules/.bin

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "carconfigurator",
     "version": "0.0.0",
     "dependencies": {
-        "montage" : ">=0.10.0 <0.12.0",
+        "montage" : "0.12.x",
         "vehicle-config" : "0.0.x",
         "m-car" : "0.0.0",
         "c2j" : "0.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "carconfigurator",
     "version": "0.0.0",
     "dependencies": {
-        "montage" : "0.10.x - 0.11.x",
+        "montage" : ">=0.10.0 <0.12.0",
         "vehicle-config" : "0.0.x",
         "m-car" : "0.0.0",
         "c2j" : "0.0.0"


### PR DESCRIPTION
The range in the dependency for montage was "0.10.x - 0.11.x" which npm 1.1.66 took as ">=0.10.0- <0.11.0-". As seen in the error:

```
npm http GET https://registry.npmjs.org/montage
npm http 304 https://registry.npmjs.org/montage
npm ERR! Error: No compatible version found: montage@'>=0.10.0- <0.11.0-'
npm ERR! Valid install targets:
npm ERR! ["0.0.0","0.11.0","0.12.0","0.12.1"]
npm ERR!     at installTargetsError (/usr/local/lib/node_modules/npm/lib/cache.js:563:10)
npm ERR!     at next (/usr/local/lib/node_modules/npm/lib/cache.js:542:17)
npm ERR!     at /usr/local/lib/node_modules/npm/lib/cache.js:522:5
npm ERR!     at saved (/usr/local/lib/node_modules/npm/node_modules/npm-registry-client/lib/get.js:138:7)
npm ERR!     at /usr/local/lib/node_modules/npm/node_modules/graceful-fs/graceful-fs.js:218:7
npm ERR!     at Object.oncomplete (fs.js:297:15)
```

This change removed the wildcards & rewrites the dependency as ">=0.10.0 <0.12.0", 
